### PR TITLE
 Add incremental updates support in Areas of Code

### DIFF
--- a/areas_code.py
+++ b/areas_code.py
@@ -20,133 +20,143 @@
 #
 
 from collections import namedtuple
+from dateutil import parser as date_parser
 
 import configparser
 import logging
+import sys
 
 from elasticsearch import Elasticsearch, helpers
+from elasticsearch_dsl import Search
 
 from grimoire_elk.elk.git import GitEnrich
 
 from df_utils.filter import FilterRows
 from enrich.enrich import FileType, FilePath, ToUTF8
-from events.events import Git
+from events.events import Git, Events
 
 import certifi
 
 # TODO read this from a file
 MAPPING_GIT = \
-{
-    "mappings": {
-        "item": {
-            "properties": {
-                "addedlines": {
-                    "type": "long"
-                },
-                "author_bot": {
-                    "type": "boolean"
-                },
-                "author_domain": {
-                    "type": "keyword"
-                },
-                "author_id": {
-                    "type": "keyword"
-                },
-                "author_name": {
-                    "type": "keyword"
-                },
-                "author_org_name": {
-                    "type": "keyword"
-                },
-                "author_user_name": {
-                    "type": "keyword"
-                },
-                "author_uuid": {
-                    "type": "keyword"
-                },
-                "committer": {
-                    "type": "keyword"
-                },
-                "committer_date": {
-                    "type": "date"
-                },
-                "date": {
-                    "type": "date"
-                },
-                "eventtype": {
-                    "type": "keyword"
-                },
-                "fileaction": {
-                    "type": "keyword"
-                },
-                "filepath": {
-                    "type": "keyword"
-                },
-                "filetype": {
-                    "type": "keyword"
-                },
-                "file_name": {
-                    "type": "keyword"
-                },
-                "file_ext": {
-                    "type": "keyword"
-                },
-                "file_dir_name": {
-                    "type": "keyword"
-                },
-                "file_path_list": {
-                    "type": "keyword"
-                },
-                "grimoire_creation_date": {
-                    "type": "date"
-                },
-                "hash": {
-                    "type": "keyword"
-                },
-                "id": {
-                    "type": "keyword"
-                },
-                "message": {
-                    "type": "text",
-                    "fields": {
-                        "keyword": {
-                            "type": "keyword",
-                            "ignore_above": 256
+    {
+        "mappings": {
+            "item": {
+                "properties": {
+                    "addedlines": {
+                        "type": "long"
+                    },
+                    "author_bot": {
+                        "type": "boolean"
+                    },
+                    "author_domain": {
+                        "type": "keyword"
+                    },
+                    "author_id": {
+                        "type": "keyword"
+                    },
+                    "author_name": {
+                        "type": "keyword"
+                    },
+                    "author_org_name": {
+                        "type": "keyword"
+                    },
+                    "author_user_name": {
+                        "type": "keyword"
+                    },
+                    "author_uuid": {
+                        "type": "keyword"
+                    },
+                    "committer": {
+                        "type": "keyword"
+                    },
+                    "committer_date": {
+                        "type": "date"
+                    },
+                    "date": {
+                        "type": "date"
+                    },
+                    "eventtype": {
+                        "type": "keyword"
+                    },
+                    "fileaction": {
+                        "type": "keyword"
+                    },
+                    "filepath": {
+                        "type": "keyword"
+                    },
+                    "files": {
+                        "type": "long"
+                    },
+                    "filetype": {
+                        "type": "keyword"
+                    },
+                    "file_name": {
+                        "type": "keyword"
+                    },
+                    "file_ext": {
+                        "type": "keyword"
+                    },
+                    "file_dir_name": {
+                        "type": "keyword"
+                    },
+                    "file_path_list": {
+                        "type": "keyword"
+                    },
+                    "grimoire_creation_date": {
+                        "type": "date"
+                    },
+                    "hash": {
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "type": "keyword"
+                    },
+                    "message": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
                         }
+                    },
+                    "metadata__enriched_on": {
+                        "type": "date"
+                    },
+                    "metadata__timestamp": {
+                        "type": "date"
+                    },
+                    "metadata__updated_on": {
+                        "type": "date"
+                    },
+                    "owner": {
+                        "type": "keyword"
+                    },
+                    "perceval_uuid": {
+                        "type": "keyword"
+                    },
+                    "project": {
+                        "type": "keyword"
+                    },
+                    "project_1": {
+                        "type": "keyword"
+                    },
+                    "removedlines": {
+                        "type": "long"
+                    },
+                    "repository": {
+                        "type": "keyword"
                     }
-                },
-                "metadata__enriched_on": {
-                    "type": "date"
-                },
-                "metadata__timestamp": {
-                    "type": "date"
-                },
-                "metadata__updated_on": {
-                    "type": "date"
-                },
-                "owner": {
-                    "type": "keyword"
-                },
-                "project": {
-                    "type": "keyword"
-                },
-                "project_1": {
-                    "type": "keyword"
-                },
-                "removedlines": {
-                    "type": "long"
-                },
-                "repository": {
-                    "type": "keyword"
                 }
             }
         }
     }
-}
 
 # Logging formats
 LOG_FORMAT = "[%(asctime)s - %(levelname)s] - %(message)s"
 DEBUG_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
+
 
 def parse_es_section(parser, es_section):
 
@@ -190,6 +200,7 @@ def parse_es_section(parser, es_section):
                      es_read_git_index=es_read_git_index,
                      es_write_git_index=es_write_git_index)
 
+
 def parse_sh_section(parser, sh_section, general_section):
 
     sh_user = parser.get(sh_section, 'db_user')
@@ -200,15 +211,17 @@ def parse_sh_section(parser, sh_section, general_section):
 
     projects_file_path = parser.get(general_section, 'projects')
 
-    #TODO add port when parameter is available
+    # TODO add port when parameter is available
     return GitEnrich(db_sortinghat=sh_name, db_user=sh_user,
                      db_password=sh_password, db_host=sh_host,
                      json_projects_map=projects_file_path)
 
+
 def parse_config(general_section='General', sh_section='SortingHat',
                  es_section='ElasticSearch'):
 
-    Config = namedtuple('Config', ['es_config', 'git_enrich', 'log_level', 'size'])
+    Config = namedtuple('Config', ['es_config', 'git_enrich', 'log_level', 'size',
+                                   'inc'])
 
     parser = configparser.ConfigParser()
     conf_file = '.settings'
@@ -222,132 +235,146 @@ def parse_config(general_section='General', sh_section='SortingHat',
 
     log_level = parser.get(general_section, 'log_level')
     size = parser.get(general_section, 'size')
+    inc = parser.get(general_section, 'inc')
 
     return Config(es_config=es_config,
                   git_enrich=git_enrich,
                   log_level=log_level,
-                  size=size)
+                  size=size,
+                  inc=inc)
 
 
-def upload_data(events_df, es_write_index, es_write, uniq_id):
+def upload_data(events_df, es_write_index, es_write):
     # Uploading info to the new ES
-    test = events_df.to_dict("index")
+    rows = events_df.to_dict("index")
     docs = []
-    for i in test.keys():
+    for row_index in rows.keys():
+        row = rows[row_index]
+        item_id = row[Events.PERCEVAL_UUID] + "_" + row[Git.FILE_PATH] +\
+            "_" + row[Git.FILE_EVENT]
         header = {
             "_index": es_write_index,
             "_type": "item",
-            "_id": int(uniq_id),
-            "_source": test[i]
+            "_id": item_id,
+            "_source": row
         }
         docs.append(header)
-        uniq_id = uniq_id + 1
-    logging.info("Written: " + str(len(docs)))
     helpers.bulk(es_write, docs)
-
-    return uniq_id
-
-# def add_sh_info(git_enrich, item):
-#     # To ensure we have procesed the entity, uncomment following lines
-#     # identities = git_enrich.get_identities(item)
-#     # SortingHat.add_identities(git_enrich.sh_db, identities, git_enrich.get_connector_name())
-#
-#     # Add the grimoire_creation_date to the raw item
-#     # It is used for getting the right affiliation
-#     item.update(git_enrich.get_grimoire_fields(item["data"]["AuthorDate"], "commit"))
-#     sh_identity = git_enrich.get_item_sh(item)
-#
-#     item['data']['author_id'] = sh_identity['author_id']
-#     item['data']['author_org_name'] = sh_identity['author_org_name']
-#     item['data']['author_name'] = sh_identity['author_name']
-#     item['data']['author_uuid'] = sh_identity['author_uuid']
-#     item['data']['author_domain'] = sh_identity['author_domain']
-#     item['data']['author_user_name'] = sh_identity['author_user_name']
-#     item['data']['author_bot'] = sh_identity['author_bot']
-#
-#     return item
-
-# def add_project_info(git_enrich, item):
-#     project_item = git_enrich.get_item_project(item)
-#     item['data']['project'] = sh_identity['author_bot']
+    logging.info("Written: " + str(len(docs)))
 
 
-def analyze_git(es_read, es_write, es_read_index, es_write_index, git_enrich,
-                size):
-
+def init_write_index(es_write, es_write_index):
+    """Initializes ES write index
+    """
+    logging.info("Initializing index: " + es_write_index)
     es_write.indices.delete(es_write_index, ignore=[400, 404])
     es_write.indices.create(es_write_index, body=MAPPING_GIT)
 
+
+def eventize_and_enrich(commits, git_enrich):
+    logging.info("New commits: " + str(len(commits)))
+
+    # Create events from commits
+    # TODO add tests for eventize method
+    git_events = Git(commits, git_enrich)
+    events_df = git_events.eventize(2)
+
+    logging.info("New events: " + str(len(events_df)))
+
+    # Filter information
+    data_filtered = FilterRows(events_df)
+    events_df = data_filtered.filter_(["filepath"], "-")
+
+    logging.info("New events filtered: " + str(len(events_df)))
+
+    # Add filetype info
+    enriched_filetype = FileType(events_df)
+    events_df = enriched_filetype.enrich('filepath')
+
+    logging.info("New Filetype events: " + str(len(events_df)))
+
+    # Split filepath info
+    enriched_filepath = FilePath(events_df)
+    events_df = enriched_filepath.enrich('filepath')
+
+    logging.info("New Filepath events: " + str(len(events_df)))
+
+    # Deal with surrogates
+    convert = ToUTF8(events_df)
+    events_df = convert.enrich(["owner"])
+
+    logging.info("Final new events: " + str(len(events_df)))
+
+    return events_df
+
+
+def analyze_git(es_read, es_write, es_read_index, es_write_index, git_enrich,
+                size, incremental):
+
+    query = {"match_all": {}}
+    sort = [{"metadata__timestamp": {"order": "asc"}}]
+
+    if incremental.lower() == 'true':
+        search = Search(using=es_write, index=es_write_index)
+        # from:to parameters (=> from: 0, size: 0)
+        search = search[0:0]
+        search = search.aggs.metric('max_date', 'max', field='metadata__timestamp')
+
+        response = search.execute()
+
+        if response.to_dict()['aggregations']['max_date']['value'] is None:
+            msg = "No data for 'metadata__timestamp' field found in "
+            msg += es_write_index + " index"
+            logging.warning(msg)
+            init_write_index(es_write, es_write_index)
+
+        else:
+            # Incremental case: retrieve items from last item in ES write index
+            max_date = response.to_dict()['aggregations']['max_date']['value_as_string']
+            max_date = date_parser.parse(max_date).isoformat()
+
+            logging.info("Starting retrieval from: " + max_date)
+            query = {"range": {"metadata__timestamp": {"gte": max_date}}}
+
+    else:
+        init_write_index(es_write, es_write_index)
+
+    search_query = {
+        "query": query,
+        "sort": sort
+    }
+
+    logging.info(search_query)
+
     logging.info("Start reading items...")
 
-    query = {"query": {"match_all" :{}}}
-
-    # s = Search(using=es_read, index=es_read_index)
-    # s.params(scroll=1)
-    # s.extra(size=10)
-
-    #s.execute()
-
     commits = []
-    cont = 1
-    uniq_id = 1
+    cont = 0
 
-    #for hit in s.scan():
-    for hit in helpers.scan(es_read, query, scroll='300m', index=es_read_index):
+    for hit in helpers.scan(es_read, search_query, scroll='300m', index=es_read_index,
+                            preserve_order=True):
+
+        cont = cont + 1
+
         item = hit["_source"]
-
-        # SH information, this should be done while eventizing
-        #item = add_sh_info(git_enrich, item)
-        #logging.info("SH info  a +dstr(ed to ite)m " + str(cont))
-
-        # TODO Project enrichment should be done in proper pandas style
-        #add_project_info(git_enrich, item)
-
         commits.append(item)
+        logging.debug("[Hit] metadata__timestamp: " + item['metadata__timestamp'])
 
         if cont % size == 0:
             logging.info("Total Items read: " + str(cont))
-            logging.info("New commits: " + str(len(commits)))
 
-            # Create events from commits
-            # TODO add tests for eventize method
-            git_events = Git(commits, git_enrich)
-            events_df = git_events.eventize(2)
-
-            logging.info("New events: " + str(len(events_df)))
-
-            # Filter information
-            data_filtered = FilterRows(events_df)
-            events_df = data_filtered.filter_(["filepath"], "-")
-
-            logging.info("New events filtered: " + str(len(events_df)))
-
-            # Add filetype info
-            enriched_filetype = FileType(events_df)
-            events_df = enriched_filetype.enrich('filepath')
-
-            #logging.info(events_df)
-            logging.info("New Filetype events: " + str(len(events_df)))
-
-            # Split filepath info
-            enriched_filepath = FilePath(events_df)
-            events_df = enriched_filepath.enrich('filepath')
-
-            #logging.info(events_df)
-            logging.info("New Filepath events: " + str(len(events_df)))
-
-            # Deal with surrogates
-            convert = ToUTF8(events_df)
-            events_df = convert.enrich(["owner"])
-
-            logging.info("Final new events: " + str(len(events_df)))
+            events_df = eventize_and_enrich(commits, git_enrich)
+            upload_data(events_df, es_write_index, es_write)
 
             commits = []
+            events_df = None
 
-            uniq_id = upload_data(events_df, es_write_index, es_write, uniq_id)
+    # In case we have some commits pending, process them
+    if len(commits) > 0:
+        logging.info("Total Items read: " + str(cont))
+        events_df = eventize_and_enrich(commits, git_enrich)
+        upload_data(events_df, es_write_index, es_write)
 
-        cont = cont + 1
-    upload_data(events_df, es_write_index, es_write, uniq_id)
 
 def configure_logging(info=False, debug=False):
     """Configure logging
@@ -361,7 +388,7 @@ def configure_logging(info=False, debug=False):
                             format=LOG_FORMAT)
         logging.getLogger('requests').setLevel(logging.WARNING)
         logging.getLogger('urrlib3').setLevel(logging.WARNING)
-        logging.getLogger('elasticsearch').setLevel(logging.INFO)
+        logging.getLogger('elasticsearch').setLevel(logging.WARNING)
     elif debug:
         logging.basicConfig(level=logging.DEBUG,
                             format=DEBUG_LOG_FORMAT)
@@ -371,6 +398,7 @@ def configure_logging(info=False, debug=False):
         logging.getLogger('requests').setLevel(logging.WARNING)
         logging.getLogger('urrlib3').setLevel(logging.WARNING)
         logging.getLogger('elasticsearch').setLevel(logging.WARNING)
+
 
 def main():
 
@@ -390,8 +418,18 @@ def main():
                 es_config.es_read_git_index,
                 es_config.es_write_git_index,
                 config.git_enrich,
-                int(config.size))
+                int(config.size),
+                incremental=config.inc)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        s = "\n\nReceived Ctrl-C or other break signal. Exiting.\n"
+        sys.stdout.write(s)
+        sys.exit(0)
+    except RuntimeError as e:
+        s = "Error: %s\n" % str(e)
+        sys.stderr.write(s)
+        sys.exit(1)

--- a/events/events.py
+++ b/events/events.py
@@ -42,6 +42,7 @@ class Events(object):
     GRIMOIRE_CREATION_DATE = "grimoire_creation_date"
     PROJECT = "project"
     PROJECT_1 = "project_1"
+    PERCEVAL_UUID = "perceval_uuid"
 
     SH_AUTHOR_ID = "author_id"
     SH_AUTHOR_ORG_NAME = "author_org_name"
@@ -84,7 +85,10 @@ class Events(object):
 
         df_columns[Events.GRIMOIRE_CREATION_DATE].append(creation_date)
 
-        #TODO add other common fields as 'perceval version', 'tag', 'origin'...
+        # Perceval fields
+        df_columns[Events.PERCEVAL_UUID].append(item['uuid'])
+
+        # TODO add other common fields as 'perceval version', 'tag', 'origin'...
 
     def _add_general_info(self, df_columns, item):
 
@@ -144,6 +148,27 @@ class Events(object):
         df_columns[Events.SH_AUTHOR_USER_NAME].append(author_username)
         df_columns[Events.SH_AUTHOR_BOT].append(author_bot)
 
+    def _init_common_fields(self, df_columns):
+        # Metadata fields
+        df_columns[Git.META_TIMESTAMP] = []
+        df_columns[Git.META_UPDATED_ON] = []
+        df_columns[Git.META_ENRICHED_ON] = []
+
+        # Common fields
+        df_columns[Events.GRIMOIRE_CREATION_DATE] = []
+        df_columns[Events.PROJECT] = []
+        df_columns[Events.PROJECT_1] = []
+        df_columns[Events.PERCEVAL_UUID] = []
+
+        # SortigHat information
+        df_columns[Git.SH_AUTHOR_ID] = []
+        df_columns[Git.SH_AUTHOR_ORG_NAME] = []
+        df_columns[Git.SH_AUTHOR_NAME] = []
+        df_columns[Git.SH_AUTHOR_UUID] = []
+        df_columns[Git.SH_AUTHOR_DOMAIN] = []
+        df_columns[Git.SH_AUTHOR_USER_NAME] = []
+        df_columns[Git.SH_AUTHOR_BOT] = []
+
     def _add_common_fields(self, df_columns, item):
         self._add_metadata(df_columns, item)
         self._add_sh_info(df_columns, item)
@@ -159,6 +184,8 @@ class Events(object):
         events[Events.PROJECT] = df_columns[Events.PROJECT]
         events[Events.PROJECT_1] = df_columns[Events.PROJECT_1]
 
+        events[Events.PERCEVAL_UUID] = df_columns[Events.PERCEVAL_UUID]
+
         events[Events.SH_AUTHOR_ID] = df_columns[Events.SH_AUTHOR_ID]
         events[Events.SH_AUTHOR_ORG_NAME] = df_columns[Events.SH_AUTHOR_ORG_NAME]
         events[Events.SH_AUTHOR_NAME] = df_columns[Events.SH_AUTHOR_NAME]
@@ -166,7 +193,6 @@ class Events(object):
         events[Events.SH_AUTHOR_DOMAIN] = df_columns[Events.SH_AUTHOR_DOMAIN]
         events[Events.SH_AUTHOR_USER_NAME] = df_columns[Events.SH_AUTHOR_USER_NAME]
         events[Events.SH_AUTHOR_BOT] = df_columns[Events.SH_AUTHOR_BOT]
-
 
 
 class Bugzilla(Events):
@@ -202,7 +228,6 @@ class Bugzilla(Events):
 
         self.items = items
 
-
     def eventize(self, granularity):
         """ This splits the JSON information found at self.events into the
         several events. For this there are three different levels of time
@@ -219,7 +244,6 @@ class Bugzilla(Events):
         :returns: Pandas dataframe with splitted events.
         :rtype: pandas.DataFrame
         """
-
 
         issue = {}
         issue[Bugzilla.ISSUE_ID] = []
@@ -242,7 +266,7 @@ class Bugzilla(Events):
                 if 'activity' in bug_data.keys():
                     activity = bug_data["activity"]
                     for change in activity:
-                        #if change["What"] == "Status":
+                        # if change["What"] == "Status":
                         # Filling a new event
                         issue[Bugzilla.ISSUE_ID].append(bug_data['bug_id'][0]['__text__'])
                         issue[Bugzilla.ISSUE_EVENT].append("ISSUE_" + change["Added"])
@@ -250,13 +274,13 @@ class Bugzilla(Events):
                         issue[Bugzilla.ISSUE_OWNER].append(change["Who"])
 
             if granularity == 2:
-                #TBD Let's produce an index with all of the changes.
+                # TBD Let's produce an index with all of the changes.
                 #    Let's have in mind the point about having the changes of initiating
                 #    the ticket.
                 pass
 
             if granularity == 3:
-                #TDB
+                # TDB
                 pass
 
         # Done in this way to have an order (and not a direct cast)
@@ -293,7 +317,6 @@ class BugzillaRest(Events):
 
         self.items = items
 
-
     def eventize(self, granularity):
         """ This splits the JSON information found at self.events into the
         several events. For this there are three different levels of time
@@ -310,7 +333,6 @@ class BugzillaRest(Events):
         :returns: Pandas dataframe with splitted events.
         :rtype: pandas.DataFrame
         """
-
 
         issue = {}
         issue[BugzillaRest.ISSUE_ID] = []
@@ -350,13 +372,13 @@ class BugzillaRest(Events):
                             issue[BugzillaRest.ISSUE_OWNER].append(who)
 
             if granularity == 2:
-                #TBD Let's produce an index with all of the changes.
+                # TBD Let's produce an index with all of the changes.
                 #    Let's have in mind the point about having the changes of initiating
                 #    the ticket.
                 pass
 
             if granularity == 3:
-                #TDB
+                # TDB
                 pass
 
         # Done in this way to have an order (and not a direct cast)
@@ -400,6 +422,7 @@ class Git(Events):
     FILE_PATH = "filepath"
     FILE_ADDED_LINES = "addedlines"
     FILE_REMOVED_LINES = "removedlines"
+    FILE_FILES = "files"
 
     def __init__(self, items, git_enrich):
         """ Main constructor of the class
@@ -411,7 +434,6 @@ class Git(Events):
         """
 
         super().__init__(items=items, enrich=git_enrich)
-
 
     def __add_commit_info(self, df_columns, item):
 
@@ -434,7 +456,6 @@ class Git(Events):
         else:
             df_columns[Git.COMMIT_MESSAGE].append('')
 
-
     def eventize(self, granularity):
         """ This splits the JSON information found at self.events into the
         several events. For this there are three different levels of time
@@ -452,24 +473,8 @@ class Git(Events):
         """
 
         df_columns = {}
-        # Metadata fields
-        df_columns[Git.META_TIMESTAMP] = []
-        df_columns[Git.META_UPDATED_ON] = []
-        df_columns[Git.META_ENRICHED_ON] = []
-
-        # Common fields
-        df_columns[Events.GRIMOIRE_CREATION_DATE] = []
-        df_columns[Events.PROJECT] = []
-        df_columns[Events.PROJECT_1] = []
-
-        # SortigHat information
-        df_columns[Git.SH_AUTHOR_ID] = []
-        df_columns[Git.SH_AUTHOR_ORG_NAME] = []
-        df_columns[Git.SH_AUTHOR_NAME] = []
-        df_columns[Git.SH_AUTHOR_UUID] = []
-        df_columns[Git.SH_AUTHOR_DOMAIN] = []
-        df_columns[Git.SH_AUTHOR_USER_NAME] = []
-        df_columns[Git.SH_AUTHOR_BOT] = []
+        # Init common columns
+        self._init_common_fields(df_columns)
 
         # First level granularity
         df_columns[Git.COMMIT_ID] = []
@@ -486,6 +491,7 @@ class Git(Events):
         df_columns[Git.COMMIT_HASH] = []
 
         # Second level of granularity
+        df_columns[Git.FILE_FILES] = []
         df_columns[Git.FILE_EVENT] = []
         df_columns[Git.FILE_PATH] = []
         df_columns[Git.FILE_ADDED_LINES] = []
@@ -511,14 +517,21 @@ class Git(Events):
                 df_columns[Git.COMMIT_ADDED_LINES] = added_lines
                 df_columns[Git.COMMIT_REMOVED_LINES] = removed_lines
 
-            #TODO: this will fail if no files are found in a commit (eg: merge)
+            # TODO: this will fail if no files are found in a commit (eg: merge)
             if granularity == 2:
                 # Add extra info about files actions, if there were any
                 if "files" in commit_data.keys():
                     files = commit_data["files"]
+                    nfiles = 0
+                    for f in files:
+                        if "action" in f.keys():
+                            nfiles += 1
+
                     for f in files:
                         self._add_common_fields(df_columns, item)
                         self.__add_commit_info(df_columns, item)
+
+                        df_columns[Git.FILE_FILES].append(nfiles)
 
                         if "action" in f.keys():
                             df_columns[Git.FILE_EVENT].append(Git.EVENT_FILE + f["action"])
@@ -550,9 +563,8 @@ class Git(Events):
                     print("Merge found, doing nothing...")
 
             if granularity == 3:
-                #TDB
+                # TDB
                 pass
-
 
         # Done in this way to have an order (and not a direct cast)
         self._add_common_events(events, df_columns)
@@ -571,13 +583,13 @@ class Git(Events):
             events[Git.COMMIT_ADDED_LINES] = df_columns[Git.COMMIT_ADDED_LINES]
             events[Git.COMMIT_REMOVED_LINES] = df_columns[Git.COMMIT_REMOVED_LINES]
         if granularity == 2:
+            events[Git.FILE_FILES] = df_columns[Git.FILE_FILES]
             events[Git.FILE_EVENT] = df_columns[Git.FILE_EVENT]
             events[Git.FILE_PATH] = df_columns[Git.FILE_PATH]
             events[Git.FILE_ADDED_LINES] = df_columns[Git.FILE_ADDED_LINES]
             events[Git.FILE_REMOVED_LINES] = df_columns[Git.FILE_REMOVED_LINES]
 
         return events
-
 
 
 class Gerrit(Events):
@@ -660,29 +672,31 @@ class Gerrit(Events):
                 # Adding the closing status updates (if there was any)
                 if changeset_data["status"] == 'ABANDONED' or \
                    changeset_data["status"] == 'MERGED':
-                       closing_date = dt.fromtimestamp(int(changeset_data["lastUpdated"]))
-                       changeset[Gerrit.CHANGESET_ID].append(changeset_data["number"])
-                       changeset[Gerrit.CHANGESET_EVENT].append(Gerrit.EVENT_ + changeset_data["status"])
-                       changeset[Gerrit.CHANGESET_DATE].append(closing_date)
-                       changeset[Gerrit.CHANGESET_REPO].append(changeset_data["project"])
-                       value = email = "notknown"
-                       if "name" in changeset_data["owner"].keys():
-                           value = changeset_data["owner"]["name"]
-                       if "username" in changeset_data["owner"].keys():
-                           value = changeset_data["owner"]["username"]
-                       if "email" in changeset_data["owner"].keys():
-                           value = changeset_data["owner"]["email"]
-                           email = changeset_data["owner"]["email"]
-                       changeset[Gerrit.CHANGESET_OWNER].append(value)
-                       changeset[Gerrit.CHANGESET_EMAIL].append(email)
-                       changeset[Gerrit.CHANGESET_VALUE].append(-10)
+                    closing_date = dt.fromtimestamp(int(changeset_data["lastUpdated"]))
+                    changeset[Gerrit.CHANGESET_ID].append(changeset_data["number"])
+                    changeset[Gerrit.CHANGESET_EVENT].append(Gerrit.EVENT_ +
+                                                             changeset_data["status"])
+                    changeset[Gerrit.CHANGESET_DATE].append(closing_date)
+                    changeset[Gerrit.CHANGESET_REPO].append(changeset_data["project"])
+                    value = email = "notknown"
+                    if "name" in changeset_data["owner"].keys():
+                        value = changeset_data["owner"]["name"]
+                    if "username" in changeset_data["owner"].keys():
+                        value = changeset_data["owner"]["username"]
+                    if "email" in changeset_data["owner"].keys():
+                        value = changeset_data["owner"]["email"]
+                        email = changeset_data["owner"]["email"]
+                    changeset[Gerrit.CHANGESET_OWNER].append(value)
+                    changeset[Gerrit.CHANGESET_EMAIL].append(email)
+                    changeset[Gerrit.CHANGESET_VALUE].append(-10)
 
             if granularity >= 2:
                 # Adding extra info about the patchsets
                 for patchset in changeset_data["patchSets"]:
                     changeset[Gerrit.CHANGESET_ID].append(changeset_data["number"])
                     changeset[Gerrit.CHANGESET_EVENT].append(Gerrit.EVENT_ + "PATCHSET_SENT")
-                    changeset[Gerrit.CHANGESET_DATE].append(dt.fromtimestamp(int(patchset["createdOn"])))
+                    changeset[Gerrit.CHANGESET_DATE].append(
+                        dt.fromtimestamp(int(patchset["createdOn"])))
                     changeset[Gerrit.CHANGESET_REPO].append(changeset_data["project"])
                     try:
                         email = "patchset_noname"
@@ -693,19 +707,22 @@ class Gerrit(Events):
                         if "email" in patchset["author"].keys():
                             value = patchset["author"]["email"]
                             email = patchset["author"]["email"]
-                    except:
+                    except KeyError:
                         value = "patchset_noname"
                     changeset[Gerrit.CHANGESET_OWNER].append(value)
                     changeset[Gerrit.CHANGESET_EMAIL].append(email)
                     changeset[Gerrit.CHANGESET_VALUE].append(-10)
-                    #print (patchset)
+                    # print (patchset)
                     if "approvals" in patchset.keys():
                         for approval in patchset["approvals"]:
                             if approval["type"] != "Code-Review":
                                 continue
                             changeset[Gerrit.CHANGESET_ID].append(changeset_data["number"])
-                            changeset[Gerrit.CHANGESET_EVENT].append(Gerrit.EVENT_ + "PATCHSET_APPROVAL_" + approval["type"])
-                            changeset[Gerrit.CHANGESET_DATE].append(dt.fromtimestamp(int(approval["grantedOn"])))
+                            changeset[Gerrit.CHANGESET_EVENT].append(
+                                Gerrit.EVENT_ +
+                                "PATCHSET_APPROVAL_" + approval["type"])
+                            changeset[Gerrit.CHANGESET_DATE].append(
+                                dt.fromtimestamp(int(approval["grantedOn"])))
                             changeset[Gerrit.CHANGESET_REPO].append(changeset_data["project"])
                             email = "approval_noname"
                             if "name" in approval["by"].keys():
@@ -720,7 +737,7 @@ class Gerrit(Events):
                             changeset[Gerrit.CHANGESET_VALUE].append(int(approval["value"]))
 
             if granularity >= 3:
-                #TDB
+                # TDB
                 pass
 
         # Done in this way to have an order (and not a direct cast)
@@ -733,7 +750,6 @@ class Gerrit(Events):
         events[Gerrit.CHANGESET_REPO] = changeset[Gerrit.CHANGESET_REPO]
 
         return events
-
 
 
 class Email(Events):
@@ -780,7 +796,6 @@ class Email(Events):
         :rtype: pandas.DataFrame
         """
 
-
         email = {}
         # First level granularity
         email[Email.EMAIL_ID] = []
@@ -802,22 +817,22 @@ class Email(Events):
                 email[Email.EMAIL_EVENT].append(Email.EVENT_OPEN)
                 try:
                     email[Email.EMAIL_DATE].append(parser.parse(email_data["Date"], ignoretz=True))
-                except:
+                except KeyError:
                     email[Email.EMAIL_DATE].append(parser.parse("1970-01-01"))
                 email[Email.EMAIL_OWNER].append(email_data["From"])
                 email[Email.EMAIL_SUBJECT].append(email_data["Subject"])
                 try:
                     email[Email.EMAIL_BODY].append(email_data["body"]["plain"])
-                except:
+                except KeyError:
                     email[Email.EMAIL_BODY].append("None")
                 email[Email.EMAIL_ORIGIN].append(origin)
 
             if granularity == 2:
-                #TDB
+                # TDB
                 pass
 
             if granularity == 3:
-                #TDB
+                # TDB
                 pass
 
         # Done in this way to have an order (and not a direct cast)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git, __pycache__, build, dist, docs, docker
+ignore = E129, E402, F841, C901
+max-line-length = 130
+


### PR DESCRIPTION
Now it is possible to build areas of code index incrementally by
running the builder with `inc=true` in the General section of
`.settings`.

To be able to build the index incrementally, we need to build
a custom `_id`, unique for each event we generate. We use the
following combination to achieve this:
Perceval_UUID + "_" + filepath + "_" + fileaction

Fixed a bug that didn't upload the last bunch of events. The
previous bunch was uploaded twice instead (it just overwrote
those items instead of uploading the new ones).

Some refactoring to get a clear view of the main loop.

Also adds support for merges filter by adding `files` field to
all items. This field will contain the number of files touched
by the given commit. This way we have this number available for
all file events generated for a commit.

Code compliant with PEP8.