### PR TITLE
[events] Fix gelk sortinghat module refactoring

### DIFF
--- a/cereslib/events/events.py
+++ b/cereslib/events/events.py
@@ -24,7 +24,7 @@ from dateutil import parser
 
 import pandas
 
-from grimoire_elk.elk.sortinghat import SortingHat
+from grimoire_elk.elk.sortinghat_gelk import SortingHat
 
 
 class Events(object):


### PR DESCRIPTION
As there is a mutual dependency between cereslib and gelk, it was
needed to refactor gelk sortinhat module to avoid collisions with
sortinhat package and its sortinhat module.

This change refactors events module according to gelk refactoring.